### PR TITLE
Two fixes

### DIFF
--- a/NoStringEvaluating/Models/Values/EvaluatorValue.cs
+++ b/NoStringEvaluating/Models/Values/EvaluatorValue.cs
@@ -67,6 +67,18 @@ public readonly struct EvaluatorValue : IEquatable<EvaluatorValue>
     /// <summary>
     /// Value
     /// </summary>
+    public EvaluatorValue(double? number)
+    {
+        if (number.HasValue)
+        {
+            TypeKey = ValueTypeKey.Number;
+            Number = number.Value;
+        } else TypeKey = ValueTypeKey.Null;
+    }
+
+    /// <summary>
+    /// Value
+    /// </summary>
     public EvaluatorValue(bool boolean)
     {
         TypeKey = ValueTypeKey.Boolean;
@@ -76,10 +88,33 @@ public readonly struct EvaluatorValue : IEquatable<EvaluatorValue>
     /// <summary>
     /// Value
     /// </summary>
+    public EvaluatorValue(bool? boolean)
+    {
+        if (boolean.HasValue)
+        {
+            TypeKey = ValueTypeKey.Boolean;
+            Boolean = boolean.Value;
+        } else TypeKey = ValueTypeKey.Null;
+    }
+
+    /// <summary>
+    /// Value
+    /// </summary>
     public EvaluatorValue(DateTime dateTime)
     {
         TypeKey = ValueTypeKey.DateTime;
         DateTime = dateTime;
+    }
+    /// <summary>
+    /// Value
+    /// </summary>
+    public EvaluatorValue(DateTime? dateTime)
+    {
+        if (dateTime.HasValue)
+        {
+            TypeKey = ValueTypeKey.DateTime;
+            DateTime = dateTime.Value;
+        } else TypeKey = ValueTypeKey.Null;
     }
 
     /// <summary>

--- a/NoStringEvaluating/Models/Values/InternalEvaluatorValue.cs
+++ b/NoStringEvaluating/Models/Values/InternalEvaluatorValue.cs
@@ -32,6 +32,22 @@ public readonly struct InternalEvaluatorValue : IEquatable<InternalEvaluatorValu
         Number = number;
     }
 
+    /// <summary>
+    /// Value for internal processing
+    /// </summary>
+    public InternalEvaluatorValue(double? number)
+    {
+        if (number.HasValue)
+        {
+            TypeKey = ValueTypeKey.Number;
+            Number = number.Value;
+        } else
+        {
+            Number = default;
+            TypeKey = ValueTypeKey.Null;
+        }
+    }
+
     internal InternalEvaluatorValue(int extraTypeId, ValueTypeKey typeKey)
     {
         _extraTypeId = extraTypeId;

--- a/NoStringEvaluating/NoStringEvaluating.xml
+++ b/NoStringEvaluating/NoStringEvaluating.xml
@@ -4014,12 +4014,27 @@
             Value
             </summary>
         </member>
+        <member name="M:NoStringEvaluating.Models.Values.EvaluatorValue.#ctor(System.Nullable{System.Double})">
+            <summary>
+            Value
+            </summary>
+        </member>
         <member name="M:NoStringEvaluating.Models.Values.EvaluatorValue.#ctor(System.Boolean)">
             <summary>
             Value
             </summary>
         </member>
+        <member name="M:NoStringEvaluating.Models.Values.EvaluatorValue.#ctor(System.Nullable{System.Boolean})">
+            <summary>
+            Value
+            </summary>
+        </member>
         <member name="M:NoStringEvaluating.Models.Values.EvaluatorValue.#ctor(System.DateTime)">
+            <summary>
+            Value
+            </summary>
+        </member>
+        <member name="M:NoStringEvaluating.Models.Values.EvaluatorValue.#ctor(System.Nullable{System.DateTime})">
             <summary>
             Value
             </summary>
@@ -4135,6 +4150,11 @@
             </summary>
         </member>
         <member name="M:NoStringEvaluating.Models.Values.InternalEvaluatorValue.#ctor(System.Double)">
+            <summary>
+            Value for internal processing
+            </summary>
+        </member>
+        <member name="M:NoStringEvaluating.Models.Values.InternalEvaluatorValue.#ctor(System.Nullable{System.Double})">
             <summary>
             Value for internal processing
             </summary>

--- a/NoStringEvaluating/Services/Keepers/Base/BaseValueKeeper.cs
+++ b/NoStringEvaluating/Services/Keepers/Base/BaseValueKeeper.cs
@@ -37,10 +37,9 @@ internal abstract class BaseValueKeeper<TModel>
 
     public TModel Get(int id)
     {
-        // Dictionary is thread safe for reading
-        if (_values.TryGetValue(id, out var res))
+        lock (_locker)
         {
-            return res;
+            if (_values.TryGetValue(id, out var res)) return res;
         }
 
         throw new ExtraTypeIdNotFoundException(id, GetType().Name);


### PR DESCRIPTION
Added Constructors so that double?, datetime?, bool? becomes a typekey = null and not a typekey = object
Fixed missing lock for thread safety in BaseValueKeeper
