### PR TITLE
Implement scientific notation

### DIFF
--- a/NoStringEvaluating.Tests/Data/EvaluateNumber.cs
+++ b/NoStringEvaluating.Tests/Data/EvaluateNumber.cs
@@ -236,7 +236,7 @@ internal static class EvaluateNumber
         yield return CreateTestModel("-4.2687556958921E08", -426875569.58921);
         yield return CreateTestModel("abs(-4.2687556958921E08)", 426875569.58921);
         yield return CreateTestModel("E", 2.7182);
-        yield return CreateTestModel("123 + E", 125.7182);
-        yield return CreateTestModel("123 + -E", 120.2817);
+        yield return CreateTestModel("1000 * 4.0000E-03 + E", 6.7182);
+        yield return CreateTestModel("-E + 1000 * 4.0000E-03", 1.2817);
     }
 }

--- a/NoStringEvaluating.Tests/Data/EvaluateNumber.cs
+++ b/NoStringEvaluating.Tests/Data/EvaluateNumber.cs
@@ -231,5 +231,7 @@ internal static class EvaluateNumber
         yield return CreateTestModel("Add(5.12, 3.03, 10.64)", 18.79);
         yield return CreateTestModel("Add(Add(Add(5, 0); Add(6)); 3)", 14);
         yield return CreateTestModel("2,7", 2.7);
+        yield return CreateTestModel("4.2687556958921E-08", 0.000000042687556958921);
+        yield return CreateTestModel("4.2687556958921E08", 426875569.58921);
     }
 }

--- a/NoStringEvaluating.Tests/Data/EvaluateNumber.cs
+++ b/NoStringEvaluating.Tests/Data/EvaluateNumber.cs
@@ -233,5 +233,10 @@ internal static class EvaluateNumber
         yield return CreateTestModel("2,7", 2.7);
         yield return CreateTestModel("4.2687556958921E-08", 0.000000042687556958921);
         yield return CreateTestModel("4.2687556958921E08", 426875569.58921);
+        yield return CreateTestModel("-4.2687556958921E08", -426875569.58921);
+        yield return CreateTestModel("abs(-4.2687556958921E08)", 426875569.58921);
+        yield return CreateTestModel("E", 2.7182);
+        yield return CreateTestModel("123 + E", 125.7182);
+        yield return CreateTestModel("123 + -E", 120.2817);
     }
 }


### PR DESCRIPTION
The goal of this Pull Request is to implement the possibility to use scentific notation as number.

At the moment, the value `4.2687556958921E-08` will be parse as `-5.281718171540955` and not `0.000000042687556958921`

@KovtunV Could you please have a look at it ? thx
